### PR TITLE
Updated `column` to use short options.

### DIFF
--- a/bin/docker-psi
+++ b/bin/docker-psi
@@ -6,4 +6,4 @@
   # truncating StartedAt to 19 gives seconds resolution: "2016-11-15T12:57:56"
   # space before `{{end}}` intentional, to separate if you have multiple networks with IP(?)
   docker ps --quiet "$@" | xargs --no-run-if-empty docker inspect --format='{{printf "%.12s" .Id}}|{{.Config.Image}}|{{.Config.Cmd}}|{{printf "%.19s" .State.StartedAt}}|{{.State.Status}}|{{range $net, $conf := .NetworkSettings.Networks}}{{$net}}:{{$conf.IPAddress}} {{end}}|{{.NetworkSettings.Ports}}|{{.Name}}'
-) | column --table --separator='|'
+) | column -t -s '|'


### PR DESCRIPTION
In my environment (ubuntu 16.04) column command does not have long options, so only `column -t -s '|'` works.